### PR TITLE
Update resolver and some version bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,21 @@ sudo: false
 language: c
 
 env:
-  - GHCVER=7.10.2
+  - GHCVER=8.0.1
 
 addons:
   apt:
     sources:
       - hvr-ghc
     packages:
-      - ghc-7.10.2
-      - cabal-install-1.22
+      - ghc-8.0.1
+      - cabal-install-1.24
       - libgmp-dev
       - wrk
 
 install:
   - (mkdir -p $HOME/.local/bin && cd $HOME/.local/bin && wget https://zalora-public.s3.amazonaws.com/tinc && chmod +x tinc)
-  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/1.22/bin:$PATH
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/1.24/bin:$PATH
   - ghc --version
   - cabal --version
   - travis_retry cabal update

--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -27,19 +27,19 @@ library
                      , Servant.QuickCheck.Internal.QuickCheck
                      , Servant.QuickCheck.Internal.Equality
                      , Servant.QuickCheck.Internal.ErrorTypes
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && < 5
                      , base-compat == 0.9.*
                      , aeson > 0.8 && < 0.12
                      , bytestring == 0.10.*
                      , case-insensitive == 1.2.*
-                     , data-default-class == 0.0.*
+                     , data-default-class == 0.1.*
                      , hspec == 2.2.*
                      , http-client == 0.4.*
                      , http-media == 0.6.*
                      , http-types > 0.8 && < 0.10
                      , mtl > 2.1 && < 2.3
                      , pretty == 1.1.*
-                     , process == 1.2.*
+                     , process == 1.4.*
                      , QuickCheck > 2.7 && < 2.9
                      , servant > 0.6 && < 0.9
                      , servant-client > 0.6 && < 0.9

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2016-04-20
+resolver: nightly-2016-09-12
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Resolver changed to `nightly-2016-09-12`.
Also, `base`, `data-default-class` and `process` bounds changed.
Needed this because we're using `base-4.9.0.0` and want to implement tests using `servant-quickcheck` in our project.
Locally it builds and all tests pass (ghc-8.0.1, stack 1.0.4.2, Ubuntu 16.04).