### PR TITLE
Fix multiple QueryParams / QueryFlags

### DIFF
--- a/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -91,9 +91,9 @@ instance (KnownSymbol x, Arbitrary c, ToHttpApiData c, HasGenRequest b)
     genRequest _ = do
       new' <- new
       old' <- old
-      return $ \burl -> let r = old' burl in r {
-          queryString = queryString r
-                     <> param <> "=" <> cs (toQueryParam new') }
+      return $ \burl -> let r = old' burl
+                            qs = queryString r in r {
+          queryString = (if BS.null qs then "" else "&") <> qs <> param <> "=" <> cs (toQueryParam new') }
       where
         old = genRequest (Proxy :: Proxy b)
         param = cs $ symbolVal (Proxy :: Proxy x)

--- a/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -15,9 +15,8 @@ import Servant
 import Servant.API.ContentTypes (AllMimeRender (..))
 import Servant.Client           (BaseUrl (..), Scheme (..))
 import Test.QuickCheck          (Arbitrary (..), Gen, elements, oneof)
-#if MIN_VERSION_servant(0,8,0)
+
 import qualified Data.ByteString as BS
-#endif
 
 
 class HasGenRequest a where
@@ -120,9 +119,8 @@ instance (KnownSymbol x, HasGenRequest b)
     genRequest _ = do
       old' <- old
       return $ \burl -> let r = old' burl
-                            newExpr = param <> "="
                             qs = queryString r in r {
-          queryString = if BS.null qs then newExpr else newExpr <> "&" <> qs }
+          queryString = if BS.null qs then param else param <> "&" <> qs }
       where
         old = genRequest (Proxy :: Proxy b)
         param = cs $ symbolVal (Proxy :: Proxy x)

--- a/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -119,8 +119,10 @@ instance (KnownSymbol x, HasGenRequest b)
     => HasGenRequest (QueryFlag x :> b) where
     genRequest _ = do
       old' <- old
-      return $ \burl -> let r = old' burl in r {
-          queryString = queryString r <> param <> "=" }
+      return $ \burl -> let r = old' burl
+                            newExpr = param <> "="
+                            qs = queryString r in r {
+          queryString = if BS.null qs then newExpr else newExpr <> "&" <> qs }
       where
         old = genRequest (Proxy :: Proxy b)
         param = cs $ symbolVal (Proxy :: Proxy x)

--- a/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -92,8 +92,9 @@ instance (KnownSymbol x, Arbitrary c, ToHttpApiData c, HasGenRequest b)
       new' <- new
       old' <- old
       return $ \burl -> let r = old' burl
+                            newExpr = param <> "=" <> cs (toQueryParam new')
                             qs = queryString r in r {
-          queryString = (if BS.null qs then "" else "&") <> qs <> param <> "=" <> cs (toQueryParam new') }
+          queryString = if BS.null qs then newExpr else newExpr <> "&" <> qs }
       where
         old = genRequest (Proxy :: Proxy b)
         param = cs $ symbolVal (Proxy :: Proxy x)

--- a/test/Servant/QuickCheck/InternalSpec.hs
+++ b/test/Servant/QuickCheck/InternalSpec.hs
@@ -33,6 +33,7 @@ spec = do
   onlyJsonObjectSpec
   notLongerThanSpec
   queryParamsSpec
+  queryFlagsSpec
 
 serversEqualSpec :: Spec
 serversEqualSpec = describe "serversEqual" $ do
@@ -123,6 +124,17 @@ queryParamsSpec = describe "QueryParams" $ do
         qs = C.unpack $ queryString req
     qs `shouldBe` "one=_&two=_"
 
+queryFlagsSpec :: Spec
+queryFlagsSpec = describe "QueryFlags" $ do
+
+  it "reduce to an HTTP query string correctly" $ do
+    let rng = mkQCGen 0
+        burl = BaseUrl Http "localhost" 80 ""
+        gen = genRequest flagsAPI
+        req = (unGen gen rng 0) burl
+        qs = C.unpack $ queryString req
+    qs `shouldBe` "one=&two="
+
 ------------------------------------------------------------------------------
 -- APIs
 ------------------------------------------------------------------------------
@@ -138,6 +150,12 @@ type ParamsAPI = QueryParam "one" () :> QueryParam "two" () :> Get '[JSON] ()
 
 paramsAPI :: Proxy ParamsAPI
 paramsAPI = Proxy
+
+type FlagsAPI = QueryFlag "one" :> QueryFlag "two" :> Get '[JSON] ()
+
+flagsAPI :: Proxy FlagsAPI
+flagsAPI = Proxy
+
 
 server :: IO (Server API)
 server = do

--- a/test/Servant/QuickCheck/InternalSpec.hs
+++ b/test/Servant/QuickCheck/InternalSpec.hs
@@ -4,7 +4,7 @@ module Servant.QuickCheck.InternalSpec (spec) where
 import           Control.Concurrent.MVar (newMVar, readMVar, swapMVar)
 import           Control.Monad.IO.Class  (liftIO)
 import qualified Data.ByteString         as BS
-import qualified Data.ByteString.Char8 as C
+import qualified Data.ByteString.Char8   as C
 import           Prelude.Compat
 import           Servant
 import           Test.Hspec              (Spec, context, describe, it, shouldBe,
@@ -121,8 +121,7 @@ queryParamsSpec = describe "QueryParams" $ do
         gen = genRequest paramsAPI
         req = (unGen gen rng 0) burl
         qs = C.unpack $ queryString req
-    qs `shouldContain` ("one=")
-    qs `shouldContain` ("&two=")
+    qs `shouldBe` "one=&two="
 
 ------------------------------------------------------------------------------
 -- APIs
@@ -135,7 +134,7 @@ type API = ReqBody '[JSON] String :> Post '[JSON] String
 api :: Proxy API
 api = Proxy
 
-type ParamsAPI = QueryParam "one" String :> QueryParam "two" String :> Get '[JSON] String
+type ParamsAPI = QueryParam "one" String :> QueryParam "two" String :> Get '[JSON] ()
 
 paramsAPI :: Proxy ParamsAPI
 paramsAPI = Proxy

--- a/test/Servant/QuickCheck/InternalSpec.hs
+++ b/test/Servant/QuickCheck/InternalSpec.hs
@@ -133,7 +133,7 @@ queryFlagsSpec = describe "QueryFlags" $ do
         gen = genRequest flagsAPI
         req = (unGen gen rng 0) burl
         qs = C.unpack $ queryString req
-    qs `shouldBe` "one=&two="
+    qs `shouldBe` "one&two"
 
 ------------------------------------------------------------------------------
 -- APIs

--- a/test/Servant/QuickCheck/InternalSpec.hs
+++ b/test/Servant/QuickCheck/InternalSpec.hs
@@ -121,7 +121,7 @@ queryParamsSpec = describe "QueryParams" $ do
         gen = genRequest paramsAPI
         req = (unGen gen rng 0) burl
         qs = C.unpack $ queryString req
-    qs `shouldBe` "one=&two="
+    qs `shouldBe` "one=_&two=_"
 
 ------------------------------------------------------------------------------
 -- APIs
@@ -134,7 +134,7 @@ type API = ReqBody '[JSON] String :> Post '[JSON] String
 api :: Proxy API
 api = Proxy
 
-type ParamsAPI = QueryParam "one" String :> QueryParam "two" String :> Get '[JSON] ()
+type ParamsAPI = QueryParam "one" () :> QueryParam "two" () :> Get '[JSON] ()
 
 paramsAPI :: Proxy ParamsAPI
 paramsAPI = Proxy


### PR DESCRIPTION
 * Add test API taking multiple `QueryParam`s
 * Add basic test using this API, generating an endpoint to ensure correct HTTP `one=foo&two=bar` query string generation is happening (that fails on `master`)
 * Fix (re)creation of query string to append `&` before the new parameter if there is already a built query string.

Fixes #23.