### PR TITLE
Upgrade hspec to 2.4.4 and use safeEvaluateExample for tests

### DIFF
--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -38,14 +38,15 @@ library
                      , case-insensitive == 1.2.*
                      , clock >= 0.7 && < 0.8
                      , data-default-class >= 0.0 && < 0.2
-                     , hspec >= 2.2 && < 2.4
+                     , hspec >= 2.4.4 && < 2.5
+                     , hspec-core >= 2.4.4 && < 2.5
                      , http-client >= 0.4.30 && < 0.6
                      , http-media == 0.6.*
                      , http-types > 0.8 && < 0.10
                      , mtl > 2.1 && < 2.3
                      , pretty == 1.1.*
                      , process >= 1.2 && < 1.5
-                     , QuickCheck > 2.7 && < 2.10
+                     , QuickCheck > 2.9 && < 2.11
                      , servant > 0.6 && < 0.10
                      , servant-client > 0.6 && < 0.10
                      , servant-server > 0.6 && < 0.10

--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -39,7 +39,6 @@ library
                      , clock >= 0.7 && < 0.8
                      , data-default-class >= 0.0 && < 0.2
                      , hspec >= 2.4.4 && < 2.5
-                     , hspec-core >= 2.4.4 && < 2.5
                      , http-client >= 0.4.30 && < 0.6
                      , http-media == 0.6.*
                      , http-types > 0.8 && < 0.10

--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -38,14 +38,14 @@ library
                      , case-insensitive == 1.2.*
                      , clock >= 0.7 && < 0.8
                      , data-default-class >= 0.0 && < 0.2
-                     , hspec >= 2.4.4 && < 2.5
+                     , hspec >= 2.2 && < 2.5
                      , http-client >= 0.4.30 && < 0.6
                      , http-media == 0.6.*
                      , http-types > 0.8 && < 0.10
                      , mtl > 2.1 && < 2.3
                      , pretty == 1.1.*
                      , process >= 1.2 && < 1.5
-                     , QuickCheck > 2.9 && < 2.11
+                     , QuickCheck > 2.7 && < 2.11
                      , servant > 0.6 && < 0.10
                      , servant-client > 0.6 && < 0.10
                      , servant-server > 0.6 && < 0.10

--- a/src/Servant/QuickCheck/Internal/QuickCheck.hs
+++ b/src/Servant/QuickCheck/Internal/QuickCheck.hs
@@ -14,8 +14,7 @@ import           Servant                  (Context (EmptyContext), HasServer,
 import           Servant.Client           (BaseUrl (..), Scheme (..))
 import           System.IO.Unsafe         (unsafePerformIO)
 import           Test.Hspec               (Expectation, expectationFailure)
-import           Test.QuickCheck          (Args (..), Result (..),
-                                           quickCheckWithResult)
+import           Test.QuickCheck          (Args (..),  Result (..), quickCheckWithResult)
 import           Test.QuickCheck.Monadic  (assert, forAllM, monadicIO, monitor,
                                            run)
 import           Test.QuickCheck.Property (counterexample)
@@ -85,11 +84,10 @@ serversEqual api burl1 burl2 args req = do
       assert False
   case r of
     Success {} -> return ()
-    Failure{..} -> readMVar deetsMVar >>= \x -> expectationFailure $
-      "Failed:\n" ++ show x
+    Failure{..} -> readMVar deetsMVar >>= \x -> expectationFailure $ "Failed:\n" ++ show x
     GaveUp { numTests = n } -> expectationFailure $ "Gave up after " ++ show n ++ " tests"
-    NoExpectedFailure {} -> expectationFailure $ "No expected failure"
-    InsufficientCoverage {} -> expectationFailure $ "Insufficient coverage"
+    NoExpectedFailure {} -> expectationFailure "No expected failure"
+    InsufficientCoverage {} -> expectationFailure "Insufficient coverage"
 
 -- | Check that a server satisfies the set of properties specified.
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,9 @@ resolver: lts-8.4
 packages:
 - '.'
 extra-deps:
-- hspec-2.3.2
-- hspec-core-2.3.2
-- hspec-discover-2.3.2
+- hspec-2.4.4
+- hspec-core-2.4.4
+- hspec-discover-2.4.4
+- quickcheck-io-0.2.0
 flags: {}
 extra-package-dbs: []

--- a/test/Servant/QuickCheck/InternalSpec.hs
+++ b/test/Servant/QuickCheck/InternalSpec.hs
@@ -10,8 +10,8 @@ import           Prelude.Compat
 import           Servant
 import           Test.Hspec              (Spec, context, describe, it, shouldBe,
                                           shouldContain)
-import           Test.Hspec.Core.Spec    (Arg, Example, Result (..), FailureReason (..),
-                                          defaultParams, evaluateExample, safeEvaluateExample)
+import           Test.Hspec.Core.Spec    (Arg, Example, Result (..),
+                                          defaultParams, safeEvaluateExample)
 import           Test.QuickCheck.Gen     (unGen)
 import           Test.QuickCheck.Random  (mkQCGen)
 import           Network.HTTP.Client     (queryString, path)
@@ -208,12 +208,6 @@ ctx = BasicAuthCheck (const . return $ NoSuchUser) :. EmptyContext
 ------------------------------------------------------------------------------
 -- Utils
 ------------------------------------------------------------------------------
-
-evalExample :: (Example e, Arg e ~ ()) => e -> IO Result
-evalExample e = evaluateExample e defaultParams ($ ()) progCallback
-  where
-    progCallback _ = return ()
-
 safeEvalExample :: (Example e, Arg e ~ ()) => e -> IO (Either SomeException Result)
 safeEvalExample e = safeEvaluateExample e defaultParams ($ ()) progCallback
   where


### PR DESCRIPTION
## Description

- Bumps Hspec dependency to 2.4.4.
- Tests: adds `show` to `err` in order to convert from `FailureReason` -> String.
- Tests: Switch to `safeEvaluateExample` in order to capture failure output and make assertions about it.

Fixes #27 .

## Notes

- hspec 2.4.0 changed `Fail` constructor to `Failure` and the constructor takes a `FailureReason`: `Failure (Maybe Location) FailureReason`