### PR TITLE
Tentatively support Servant 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - STACK_YAML=stack.yaml
   - STACK_YAML=stack-lts-7.yaml
   - STACK_YAML=stack-lts-6.yaml
+  - STACK_YAML=stack-lts-9.yaml
 
 
 addons:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -2,6 +2,15 @@ upcoming:
 
 releases:
 
+  - version: "0.0.3.1"
+    changes:
+
+      - description: Support for Servant 0.11
+        issue: none
+        pr: 32
+        authors: adinapoli-iohk
+        date: 2017-10-18
+
   - version: "0.0.3.0"
     changes:
 

--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -46,9 +46,9 @@ library
                      , pretty == 1.1.*
                      , process >= 1.2 && < 1.5
                      , QuickCheck > 2.7 && < 2.11
-                     , servant > 0.6 && < 0.10
-                     , servant-client > 0.6 && < 0.10
-                     , servant-server > 0.6 && < 0.10
+                     , servant > 0.6 && < 0.12
+                     , servant-client > 0.6 && < 0.12
+                     , servant-server > 0.6 && < 0.12
                      , split == 0.2.*
                      , string-conversions > 0.3 && < 0.5
                      , temporary == 1.2.*

--- a/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -64,6 +64,10 @@ instance (KnownSymbol path, HasGenRequest b) => HasGenRequest (path :> b) where
         (oldf, old) = genRequest (Proxy :: Proxy b)
         new = cs $ symbolVal (Proxy :: Proxy path)
 
+#if MIN_VERSION_servant(0,11,0)
+instance HasGenRequest EmptyAPI where
+  genRequest _ = (0, error "EmptyAPIs cannot be queried.")
+#endif
 
 instance (Arbitrary c, HasGenRequest b, ToHttpApiData c )
     => HasGenRequest (Capture x c :> b) where

--- a/stack-lts-9.yaml
+++ b/stack-lts-9.yaml
@@ -1,0 +1,6 @@
+resolver: lts-9.1
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/test/Servant/QuickCheck/InternalSpec.hs
+++ b/test/Servant/QuickCheck/InternalSpec.hs
@@ -38,7 +38,6 @@ import Servant.QuickCheck
 import Servant.QuickCheck.Internal (genRequest, runGenRequest,
                                     serverDoesntSatisfy)
 
-
 spec :: Spec
 spec = do
   serversEqualSpec


### PR DESCRIPTION
Hey @jkarni & @alpmestan!

This PR tentatively adds support for Servant 0.11. As I am in "I don't know what I'm doing" mode, it's totally possible that the `HasGenRequest EmptyAPI` instance is totally rubbish 😀 .

I have also added a `stack-lts-9.yaml` manifest to allow building with GHC 8.x.

Let me know if this has any hope of landing on master and if there is a better way of writing such instance which does not require `error` 😞 