### PR TITLE
[READY] Fixes #7: Add HTML missing Doctype predicate with tests

### DIFF
--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -90,10 +90,12 @@ test-suite spec
                      , hspec
                      , hspec-core
                      , http-client
+                     , blaze-html
                      , warp
                      , servant-server
                      , servant-client
                      , servant
+                     , servant-blaze
                      , transformers
                      , QuickCheck
                      , quickcheck-io

--- a/src/Servant/QuickCheck.hs
+++ b/src/Servant/QuickCheck.hs
@@ -34,6 +34,9 @@ module Servant.QuickCheck
   , getsHaveCacheControlHeader
   , headsHaveCacheControlHeader
   , createContainsValidLocation
+    -- * Html Predicates
+  , htmlIncludesDoctype
+
   -- *** Predicate utilities and types
   , (<%>)
   , Predicates

--- a/src/Servant/QuickCheck/Internal/Predicates.hs
+++ b/src/Servant/QuickCheck/Internal/Predicates.hs
@@ -357,7 +357,7 @@ htmlIncludesDoctype
   = ResponsePredicate $ \resp ->
       if hasValidHeader "Content-Type" (SBS.isPrefixOf . foldCase $ "text/html") resp
         then do
-            let htmlContent = foldCase $ responseBody resp
+            let htmlContent = foldCase . LBS.take 20 $ responseBody resp
             unless (LBS.isPrefixOf (foldCase "<!doctype html>") htmlContent) $
               throw $ PredicateFailure "htmlIncludesDoctype" Nothing resp
         else return ()

--- a/src/Servant/QuickCheck/Internal/Predicates.hs
+++ b/src/Servant/QuickCheck/Internal/Predicates.hs
@@ -341,11 +341,16 @@ unauthorizedContainsWWWAuthenticate
         else return ()
 
 
--- | [__Best Practice__]
+-- | [__RFC Compliance__]
 --
--- Checks that HTML documents (those with `Content-Type: text/html...`)
--- include a DOCTYPE declaration at the top.
+-- [An HTML] document will start with exactly this string: <!DOCTYPE html>
 --
+-- This function checks that HTML documents (those with `Content-Type: text/html...`)
+-- include a DOCTYPE declaration at the top. We do not enforce capital case for the string `DOCTYPE`.
+--
+-- __References__:
+--
+--  * HTML5 Doctype: <https://tools.ietf.org/html/rfc7992#section-6.1 RFC 7992 Section 6.1>
 -- /Since 0.3.0.0/
 htmlIncludesDoctype :: ResponsePredicate
 htmlIncludesDoctype

--- a/test/Servant/QuickCheck/InternalSpec.hs
+++ b/test/Servant/QuickCheck/InternalSpec.hs
@@ -12,6 +12,9 @@ import           Data.Maybe              (fromJust)
 import           Network.HTTP.Client     (path, queryString)
 import           Prelude.Compat
 import           Servant
+import           Servant.HTML.Blaze      (HTML)
+import qualified Text.Blaze.Html         as Blaze
+import qualified Text.Blaze.Html5        as Blaze5
 import           Test.Hspec              (Spec, context, describe, it, shouldBe,
                                           shouldContain)
 import           Test.Hspec.Core.Spec    (Arg, Example, Result (..),
@@ -49,6 +52,7 @@ spec = do
   queryParamsSpec
   queryFlagsSpec
   deepPathSpec
+  htmlDocTypesSpec
   unbiasedGenerationSpec
 
 serversEqualSpec :: Spec
@@ -190,6 +194,25 @@ queryFlagsSpec = describe "QueryFlags" $ do
         qs = C.unpack $ queryString req
     qs `shouldBe` "one&two"
 
+htmlDocTypesSpec :: Spec
+htmlDocTypesSpec = describe "HtmlDocTypes" $ do
+
+    it "fails HTML without doctype correctly" $ do
+      err <- withServantServerAndContext docTypeApi ctx noDocTypeServer $ \burl -> do
+        evalExample $ serverSatisfies docTypeApi burl args
+          (htmlIncludesDoctype <%> mempty)
+      show err `shouldContain` "htmlIncludesDoctype"
+
+    it "passes HTML with a doctype at start" $ do
+      withServantServerAndContext docTypeApi ctx docTypeServer $ \burl ->
+        serverSatisfies docTypeApi burl args (htmlIncludesDoctype <%> mempty)
+
+    it "accepts json endpoints and passes over them in silence" $ do
+      withServantServerAndContext api ctx server $ \burl -> do
+        serverSatisfies (Proxy :: Proxy (Get '[JSON] Int)) burl args
+          (htmlIncludesDoctype <%> mempty)
+
+
 makeRandomRequest :: Proxy LargeAPI -> BaseUrl -> IO Integer
 makeRandomRequest large burl = do
   req <- generate $ runGenRequest large
@@ -259,7 +282,20 @@ server2 = return $ return 1
 server3 :: IO (Server API2)
 server3 = return $ return 2
 
+-- With Doctypes
+type HtmlDoctype = Get '[HTML] Blaze.Html
 
+docTypeApi :: Proxy HtmlDoctype
+docTypeApi = Proxy
+
+docTypeServer :: IO (Server HtmlDoctype)
+docTypeServer = pure $ pure $ Blaze5.docTypeHtml $ Blaze5.span "Hello Test!"
+
+noDocTypeServer :: IO (Server HtmlDoctype)
+noDocTypeServer = pure $ pure $ Blaze.text "Hello Test!"
+
+
+-- Api for unbiased generation of requests tests
 largeApi :: Proxy LargeAPI
 largeApi = Proxy
 


### PR DESCRIPTION
## Description

This PR adds an HTML Doctype predicate for ensuring that HTML returned *starts with* `<!DOCTYPE html>` (case doesn't matter).

## Notes

- [x] Still need to complete references in documentation

- [x] Fix failing test (see below)

@jkarni this is the branch with the odd (to me) test failure. The code will build and tests will run but the test that checks that this predicate actually works, fails like this:

```
Failures:

  test/Servant/QuickCheck/InternalSpec.hs:176: 
  1) Servant.QuickCheck.Internal.HtmlDocTypes fails HTML without doctype correctly
       "AnException should not be called\nCallStack (from HasCallStack):\n  error, called at src/Servant/QuickCheck/Internal/QuickCheck.hs:115:26 in servant-quickcheck-0.0.2.4-2MoBWSLmK9eFJsRwyw6GL3:Servant.QuickCheck.Internal.QuickCheck" does not contain "htmlIncludesDoctype"

Randomized with seed 538656686

Finished in 3.3739 seconds
17 examples, 1 failure
```