### PR TITLE
[WAIT] Issue 14: Add Request to ResponsePredicate

### DIFF
--- a/src/Servant/QuickCheck/Internal/ErrorTypes.hs
+++ b/src/Servant/QuickCheck/Internal/ErrorTypes.hs
@@ -12,7 +12,7 @@ import           Prelude.Compat
 import           Text.PrettyPrint
 
 data PredicateFailure
-  = PredicateFailure T.Text (Maybe C.Request) (C.Response LBS.ByteString)
+  = PredicateFailure T.Text (C.Request) (C.Response LBS.ByteString)
   deriving (Typeable, Generic)
 
 instance Exception ServerEqualityFailure where
@@ -71,10 +71,5 @@ prettyPredicateFailure :: PredicateFailure -> Doc
 prettyPredicateFailure (PredicateFailure predicate req resp) =
   text "Predicate failed" $$ (nest 5 $
      text "Predicate:" <+> (text $ T.unpack predicate)
-  $$ r
+  $$ prettyReq req
   $$ prettyResp resp)
-  where
-    r = case req of
-      Nothing -> text ""
-      Just v  -> prettyReq v
-


### PR DESCRIPTION
## Description

This PR does the following:

- Adds the `Request` to `ResponsePredicate` so that `PredicateFailure` can pretty print the request as well as the failing response.

- Removes the `Maybe` from `PredicateFailure (Maybe Request)` now that both `RequestFailure` and `ResponseFailure` require the request.

- Adds tests for the following predicates: `not500` and `unauthorizedContainsWWWAuthenticate` 

Fixes #14 