### PR TITLE
Add forgotten predicates to export list.

### DIFF
--- a/src/Servant/QuickCheck.hs
+++ b/src/Servant/QuickCheck.hs
@@ -29,8 +29,10 @@ module Servant.QuickCheck
   , not500
   , notLongerThan
   , onlyJsonObjects
+  , honoursAcceptHeader
   , notAllowedContainsAllowHeader
   , unauthorizedContainsWWWAuthenticate
+  , getsHaveLastModifiedHeader
   , getsHaveCacheControlHeader
   , headsHaveCacheControlHeader
   , createContainsValidLocation


### PR DESCRIPTION
The `honoursAcceptHeader` and `getsHaveLastModifiedHeader` Predicates had
been omitted when writing the export list, making it necessary to import
`Servant.QuickCheck.Internal.Predicates` to have access to them.