### PR TITLE
Remove base-compat-batteries dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ samples/
 test-servers/
 /doc/
 .stack-work/
+dist-newstyle/

--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -37,7 +37,7 @@ library
                      , Servant.QuickCheck.Internal.Equality
                      , Servant.QuickCheck.Internal.ErrorTypes
   build-depends:       base >=4.8 && <4.12
-                     , base-compat-batteries >= 0.10.1 && <0.11
+                     , base-compat >= 0.10.1 && <0.11
                      , aeson > 0.8 && < 2
                      , bytestring == 0.10.*
                      , case-insensitive == 1.2.*
@@ -93,7 +93,7 @@ test-suite spec
   other-modules:       Servant.QuickCheck.InternalSpec
   build-tool-depends:  hspec-discover:hspec-discover
   build-depends:       base
-                     , base-compat-batteries
+                     , base-compat
                      , aeson
                      , servant-quickcheck
                      , bytestring

--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -106,7 +106,7 @@ test-suite spec
                      , servant-client
                      , servant
                      , servant-blaze
-                     , transformers
+                     -- , transformers
                      , QuickCheck
                      , quickcheck-io
   default-extensions:  TypeOperators

--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -37,7 +37,7 @@ library
                      , Servant.QuickCheck.Internal.Equality
                      , Servant.QuickCheck.Internal.ErrorTypes
   build-depends:       base >=4.8 && <4.12
-                     , base-compat >= 0.10.1 && <0.11
+                     , base-compat >= 0.9.3 && <0.11
                      , aeson > 0.8 && < 2
                      , bytestring == 0.10.*
                      , case-insensitive == 1.2.*

--- a/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -15,6 +15,10 @@ import Servant.API.ContentTypes (AllMimeRender (..))
 import Servant.Client           (BaseUrl (..), Scheme (..))
 import Test.QuickCheck          (Arbitrary (..), Gen, elements, frequency)
 
+#if __GLASGOW_HASKELL__ <= 800
+import Data.Monoid ((<>))
+#endif
+
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BS (c2w)
 

--- a/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -15,9 +15,7 @@ import Servant.API.ContentTypes (AllMimeRender (..))
 import Servant.Client           (BaseUrl (..), Scheme (..))
 import Test.QuickCheck          (Arbitrary (..), Gen, elements, frequency)
 
-#if __GLASGOW_HASKELL__ <= 800
 import Data.Monoid ((<>))
-#endif
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BS (c2w)

--- a/src/Servant/QuickCheck/Internal/QuickCheck.hs
+++ b/src/Servant/QuickCheck/Internal/QuickCheck.hs
@@ -19,6 +19,10 @@ import           Test.QuickCheck.Monadic  (assert, forAllM, monadicIO, monitor,
                                            run)
 import           Test.QuickCheck.Property (counterexample)
 
+#if __GLASGOW_HASKELL__ <= 800
+import Data.Monoid ((<>))
+#endif
+
 import Servant.QuickCheck.Internal.Equality
 import Servant.QuickCheck.Internal.ErrorTypes
 import Servant.QuickCheck.Internal.HasGenRequest

--- a/src/Servant/QuickCheck/Internal/QuickCheck.hs
+++ b/src/Servant/QuickCheck/Internal/QuickCheck.hs
@@ -19,9 +19,7 @@ import           Test.QuickCheck.Monadic  (assert, forAllM, monadicIO, monitor,
                                            run)
 import           Test.QuickCheck.Property (counterexample)
 
-#if __GLASGOW_HASKELL__ <= 800
 import Data.Monoid ((<>))
-#endif
 
 import Servant.QuickCheck.Internal.Equality
 import Servant.QuickCheck.Internal.ErrorTypes

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,6 @@ resolver: lts-11.8
 packages:
 - '.'
 extra-deps:
-- base-compat-batteries-0.10.1
 - base-compat-0.10.1
 - hspec-discover-2.5.0
 - hspec-core-2.5.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,12 +2,12 @@ resolver: lts-11.8
 packages:
 - '.'
 extra-deps:
-- base-compat-0.10.1
+    # - base-compat-0.10.1
 - hspec-discover-2.5.0
 - hspec-core-2.5.0
 - hspec-2.5.0
 # aeson pre-1.3.1.0 has an upper bound on `base-compat-batteries` that preclude
 # the 0.10.1 that we depend on
-- aeson-1.3.1.0
+# - aeson-1.3.1.0
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
We're having some issues with the `base-compat-batteries` dependency, and it seems to be unused. This removes it in favor of the `base-compat` dependency which we are carrying.