### PR TITLE
Fix a failure from OnlyJsonObjects when there is no content-type.

### DIFF
--- a/test/Servant/QuickCheck/InternalSpec.hs
+++ b/test/Servant/QuickCheck/InternalSpec.hs
@@ -133,6 +133,10 @@ onlyJsonObjectSpec = describe "onlyJsonObjects" $ do
     withServantServerAndContext octetAPI ctx serverOctetAPI $ \burl ->
       serverSatisfies octetAPI burl args (onlyJsonObjects <%> mempty)
 
+  it "does not fail when there is no content-type" $ do
+    withServantServerAndContext api2 ctx serverFailing $ \burl ->
+        serverSatisfies api2 burl args (onlyJsonObjects <%> mempty)
+
 notLongerThanSpec :: Spec
 notLongerThanSpec = describe "notLongerThan" $ do
 
@@ -273,6 +277,9 @@ server2 = return $ return 1
 
 server3 :: IO (Server API2)
 server3 = return $ return 2
+
+serverFailing :: IO (Server API2)
+serverFailing = return . throwError $ err405
 
 -- With Doctypes
 type HtmlDoctype = Get '[HTML] Blaze.Html


### PR DESCRIPTION
It can happen that during testing with servant-quickcheck, the server will answer a response with no `content-type` header (e.g. a 502 or 405 response). The `OnlyJsonObjects` predicate considered these cases as a failure for itself, which made no sense since the responses hold no content.

This PR aims at fixing that, by first adding a check that verifies this behavior does not happen, and then fixing the predicate. (I also believe the new predicate is clearer to read, but that's opinion).