### PR TITLE
QuickCheck 2.12 Compatibility

### DIFF
--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -44,7 +44,7 @@ library
                      , case-insensitive == 1.2.*
                      , clock >= 0.7 && < 0.8
                      , data-default-class >= 0.0 && < 0.2
-                     , hspec >= 2.5.5 && < 2.6
+                     , hspec >= 2.5.6 && < 2.6
 
                      , http-client >= 0.4.30 && < 0.6
                      , http-media >= 0.6 && <0.8

--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -44,14 +44,15 @@ library
                      , case-insensitive == 1.2.*
                      , clock >= 0.7 && < 0.8
                      , data-default-class >= 0.0 && < 0.2
-                     , hspec >= 2.5 && < 2.6
+                     , hspec >= 2.5.5 && < 2.6
+
                      , http-client >= 0.4.30 && < 0.6
                      , http-media >= 0.6 && <0.8
                      , http-types > 0.8 && < 0.13
                      , mtl > 2.1 && < 2.3
                      , pretty == 1.1.*
                      , process >= 1.2 && < 1.7
-                     , QuickCheck > 2.7 && < 2.12
+                     , QuickCheck > 2.7 && < 2.13
                      , servant >= 0.13 && < 0.15
                      , servant-client >= 0.13 && < 0.15
                      , servant-server >= 0.13 && < 0.15
@@ -99,7 +100,7 @@ test-suite spec
                      , servant-quickcheck
                      , bytestring
                      , hspec
-                     , hspec-core
+                     , hspec-core >= 2.5.5 && < 2.6
                      , http-client
                      , blaze-html
                      , warp

--- a/src/Servant/QuickCheck/Internal/QuickCheck.hs
+++ b/src/Servant/QuickCheck/Internal/QuickCheck.hs
@@ -92,7 +92,10 @@ serversEqual api burl1 burl2 args req = do
           expectationFailure $ "We failed to record a reason for failure: " <> show r
     GaveUp { numTests = n } -> expectationFailure $ "Gave up after " ++ show n ++ " tests"
     NoExpectedFailure {} -> expectationFailure "No expected failure"
+#if MIN_VERSION_QuickCheck(2,12,0)
+#else
     InsufficientCoverage {} -> expectationFailure "Insufficient coverage"
+#endif
 
 -- | Check that a server satisfies the set of properties specified.
 --
@@ -145,7 +148,10 @@ serverSatisfiesMgr api manager burl args preds = do
           expectationFailure $ "We failed to record a reason for failure: " <> show r
     GaveUp { numTests = n } -> expectationFailure $ "Gave up after " ++ show n ++ " tests"
     NoExpectedFailure {} -> expectationFailure $ "No expected failure"
-    InsufficientCoverage {} -> expectationFailure $ "Insufficient coverage"
+#if MIN_VERSION_QuickCheck(2,12,0)
+#else
+    InsufficientCoverage {} -> expectationFailure "Insufficient coverage"
+#endif
 
 serverDoesntSatisfy :: (HasGenRequest a) =>
   Proxy a -> BaseUrl -> Args -> Predicates -> Expectation
@@ -163,7 +169,10 @@ serverDoesntSatisfyMgr api manager burl args preds = do
     GaveUp { numTests = n } -> expectationFailure $ "Gave up after " ++ show n ++ " tests"
     Failure { output = m } -> expectationFailure $ "Failed:\n" ++ show m
     NoExpectedFailure {} -> expectationFailure $ "No expected failure"
-    InsufficientCoverage {} -> expectationFailure $ "Insufficient coverage"
+#if MIN_VERSION_QuickCheck(2,12,0)
+#else
+    InsufficientCoverage {} -> expectationFailure "Insufficient coverage"
+#endif
 
 noCheckStatus :: C.Request -> C.Request
 #if MIN_VERSION_http_client(0,5,0)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,15 @@
-resolver: lts-11.8
+resolver: nightly-2018-09-03
 packages:
 - '.'
 extra-deps:
 - base-compat-batteries-0.10.1
 - base-compat-0.10.1
-- hspec-discover-2.5.0
-- hspec-core-2.5.0
-- hspec-2.5.0
+- hspec-discover-2.5.6
+- hspec-core-2.5.6
+- hspec-2.5.6
 # aeson pre-1.3.1.0 has an upper bound on `base-compat-batteries` that preclude
 # the 0.10.1 that we depend on
-- aeson-1.3.1.0
+# - aeson-1.3.1.0
+- QuickCheck-2.12
 flags: {}
 extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,14 +2,9 @@ resolver: nightly-2018-09-03
 packages:
 - '.'
 extra-deps:
-- base-compat-batteries-0.10.1
-- base-compat-0.10.1
 - hspec-discover-2.5.6
 - hspec-core-2.5.6
 - hspec-2.5.6
-# aeson pre-1.3.1.0 has an upper bound on `base-compat-batteries` that preclude
-# the 0.10.1 that we depend on
-# - aeson-1.3.1.0
 - QuickCheck-2.12
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
This commit relaxes the bounds on QuickCheck, allowing it to be
compatible with 2.12. In order to be compatible with 2.12, we had to CPP
some definitions that referenced code that was deleted.

cf https://github.com/commercialhaskell/stackage/issues/3949