### PR TITLE
test without batteries

### DIFF
--- a/servant-quickcheck.cabal
+++ b/servant-quickcheck.cabal
@@ -39,7 +39,8 @@ library
                      , Servant.QuickCheck.Internal.Equality
                      , Servant.QuickCheck.Internal.ErrorTypes
   build-depends:       base >=4.8 && <4.13
-                     , base-compat-batteries >= 0.10.1 && <0.11
+                     , base-compat >= 0.9 && < 0.11
+                     -- , base-compat-batteries >= 0.9 && <0.11
                      , aeson > 0.8 && < 2
                      , bytestring == 0.10.*
                      , case-insensitive == 1.2.*

--- a/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -15,6 +15,8 @@ import Servant.API.ContentTypes (AllMimeRender (..))
 import Servant.Client           (BaseUrl (..), Scheme (..))
 import Test.QuickCheck          (Arbitrary (..), Gen, elements, frequency)
 
+import Data.Monoid ((<>))
+
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BS (c2w)
 

--- a/src/Servant/QuickCheck/Internal/QuickCheck.hs
+++ b/src/Servant/QuickCheck/Internal/QuickCheck.hs
@@ -18,6 +18,7 @@ import           Test.QuickCheck          (Args (..),  Result (..), quickCheckWi
 import           Test.QuickCheck.Monadic  (assert, forAllM, monadicIO, monitor,
                                            run)
 import           Test.QuickCheck.Property (counterexample)
+import Data.Monoid ((<>))
 
 import Servant.QuickCheck.Internal.Equality
 import Servant.QuickCheck.Internal.ErrorTypes

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-09-03
+resolver: lts-11.13
 packages:
 - '.'
 extra-deps:


### PR DESCRIPTION
the `base-compat-batteries` dependency is causing problems when trying to use this in a `lts-11`, as *lots* of stuff gets pretty mad if the `base-compat-` version is off

testing this to see if there are errors/warnings, don't merge