### PR TITLE
Update to recent LTS, GHC 8.10, and servant 0.18.

### DIFF
--- a/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -82,16 +82,10 @@ instance (Arbitrary c, HasGenRequest b, ToHttpApiData c )
         (oldf, old) = genRequest (Proxy :: Proxy b)
         new = arbitrary :: Gen c
 
-instance (Arbitrary a, HasGenRequest b, ToHttpApiData a)
-    => HasGenRequest (Fragment a :> b) where
-    genRequest _ = (oldf, do
-      old' <- old
-      new' <- toUrlPiece <$> new
-      return $ \burl -> let r = old' burl in r { path = path r <> cs new' })
-      where
-        (oldf, old) = genRequest (Proxy :: Proxy b)
-        new = arbitrary :: Gen a
-      
+instance HasGenRequest a
+    => HasGenRequest (Fragment f :> a) where
+    genRequest _ = genRequest (Proxy :: Proxy a)
+
 instance (Arbitrary c, HasGenRequest b, ToHttpApiData c )
     => HasGenRequest (CaptureAll x c :> b) where
     genRequest _ = (oldf, do

--- a/src/Servant/QuickCheck/Internal/HasGenRequest.hs
+++ b/src/Servant/QuickCheck/Internal/HasGenRequest.hs
@@ -82,6 +82,16 @@ instance (Arbitrary c, HasGenRequest b, ToHttpApiData c )
         (oldf, old) = genRequest (Proxy :: Proxy b)
         new = arbitrary :: Gen c
 
+instance (Arbitrary a, HasGenRequest b, ToHttpApiData a)
+    => HasGenRequest (Fragment a :> b) where
+    genRequest _ = (oldf, do
+      old' <- old
+      new' <- toUrlPiece <$> new
+      return $ \burl -> let r = old' burl in r { path = path r <> cs new' })
+      where
+        (oldf, old) = genRequest (Proxy :: Proxy b)
+        new = arbitrary :: Gen a
+      
 instance (Arbitrary c, HasGenRequest b, ToHttpApiData c )
     => HasGenRequest (CaptureAll x c :> b) where
     genRequest _ = (oldf, do
@@ -195,3 +205,4 @@ instance (HasGenRequest a) => HasGenRequest (WithNamedContext x y a) where
 -- TODO: Try logging in
 instance (HasGenRequest a) => HasGenRequest (BasicAuth x y :> a) where
     genRequest _ = genRequest (Proxy :: Proxy a)
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,12 @@
-resolver: nightly-2018-09-03
+resolver:
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/2.yaml
+
 packages:
 - '.'
-extra-deps:
-- hspec-discover-2.5.6
-- hspec-core-2.5.6
-- hspec-2.5.6
-- QuickCheck-2.12
+extra-deps: []
+#- hspec-discover-2.5.6
+#- hspec-core-2.5.6
+#- hspec-2.5.6
+#- QuickCheck-2.12
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
Since servant-0.18 is now included in LTS 17.*, I decided to update servant-quickcheck to work with it.
It simplifies stack.yaml dependencies too, and requires a small addition of instance for HasGenRequest (Fragment a :> b).